### PR TITLE
Improve `verbose` behavior

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -21,9 +21,9 @@ async function run() {
   } = ts.parseCommandLine(args);
 
   const help = args.includes('--help') || args.includes('-h');
-  const verboseMatch = /--verbose(?:=([^\s$]+))?(\s|$)/.exec(args);
+  const [ _verbose, _verboseGrep ] = args.flatMap(arg => /^--verbose(?:=(.*))?$/.exec(arg) || []);
 
-  const verbose = verboseMatch ? verboseMatch[1] || true : false;
+  const verbose = _verbose ? _verboseGrep || true : false;
   const recursive = args.includes('--recursive') || args.includes('-r');
 
   if (help) {

--- a/lib/generate-types.js
+++ b/lib/generate-types.js
@@ -76,5 +76,9 @@ function isVerbose(options, fileName) {
     return options.verbose;
   }
 
+  if (typeof options.verbose === 'undefined') {
+    return false;
+  }
+
   return fileName.includes(options.verbose);
 }

--- a/lib/generate-types.js
+++ b/lib/generate-types.js
@@ -30,18 +30,18 @@ export default function generateTypes(fileNames, options) {
     // @ts-expect-error
     let src = host._readFile(fileName);
 
-    isVerbose(options, fileName) && console.debug('[generate-types] [pre]', fileName, src);
-
     if (names.has(path.resolve(fileName))) {
+      isVerbose(options, fileName) && console.debug('[generate-types] [pre]', fileName, src);
+
       try {
         src = preTransform(src);
       } catch (err) {
-        console.error(`failed to parse ${fileName} [pre] with contents ${src}`, err);
+        console.error(`[generate-types] [pre] failed to parse ${fileName} with contents ${src}`, err);
         throw err;
       }
-    }
 
-    isVerbose(options, fileName) && console.debug('[generate-types] [pre] [generated]', fileName, src);
+      isVerbose(options, fileName) && console.debug('[generate-types] [pre] [generated]', fileName, src);
+    }
 
     return src;
   };
@@ -55,7 +55,7 @@ export default function generateTypes(fileNames, options) {
     try {
       text = postTransform(text);
     } catch (err) {
-      console.error(`failed to parse ${fileName} [post] with contents ${text}`, err);
+      console.error(`[generate-types] [post] failed to parse ${fileName} with contents ${text}`, err);
       throw err;
     }
 


### PR DESCRIPTION
* Ensure it only logs relevant (touched) files
* Ensure it works including the pattern matching, i.e. `npx bio-dts -r some-folder --verbose=this-file`