### PR TITLE
Use `typescript@5.7.3`, indicate typescript compile errors

### DIFF
--- a/lib/generate-types.js
+++ b/lib/generate-types.js
@@ -79,7 +79,7 @@ export default function generateTypes(fileNames, options, ts) {
 
   const program = ts.createProgram(fileNames, options, host);
 
-  program.emit();
+  return program.emit();
 }
 
 function isVerbose(options, fileName) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-bpmn-io": "^1.0.0",
         "mocha": "^10.8.2",
         "npm-run-all2": "^7.0.2",
-        "typescript": "^5.3.3"
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2975,10 +2975,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5271,9 +5272,9 @@
       }
     },
     "typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-bpmn-io": "^1.0.0",
     "mocha": "^10.8.2",
     "npm-run-all2": "^7.0.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.7.3"
   },
   "files": [
     "bin",


### PR DESCRIPTION
Tests against TypeScript@5.7.3, improves typescript integration.