### PR TITLE
Support destructured (annonymous) arguments

### DIFF
--- a/lib/post-transform.js
+++ b/lib/post-transform.js
@@ -127,7 +127,7 @@ export default function transform(src) {
 
       const actualName = param.argument?.name || param.name;
 
-      if (actualName !== expectedName) {
+      if (isNamedParam(param) && actualName !== expectedName) {
         throw error(node, `documented parameter <${ expectedName }> differs from actual parameter <${ actualName }>`);
       }
 
@@ -210,7 +210,8 @@ export default function transform(src) {
         variations.forEach((variation) => {
           const builder = {
             'RestElement': b.restElement,
-            'Identifier': b.identifier
+            'Identifier': b.identifier,
+            'ObjectPattern': b.objectPattern
           }[param.type];
 
           variation.push(builder.from(param));
@@ -680,6 +681,10 @@ function getHostPath(nodePath) {
   return [ 'ExportDefaultDeclaration', 'ExportNamedDeclaration' ].includes(nodePath.parentPath.value.type)
     ? nodePath.parentPath
     : nodePath;
+}
+
+function isNamedParam(param) {
+  return param.type === 'Identifier' || param.type == 'RestElement';
 }
 
 /**

--- a/test/fixtures/post/jsdoc-function.d.ts
+++ b/test/fixtures/post/jsdoc-function.d.ts
@@ -15,3 +15,11 @@ declare function woop(arg?: string): void
  * @param {string} foo
  */
 export declare function exportedFn(foo): void
+
+/**
+ * @param { { a: number, b: string } } options
+ */
+export function foo({ a, b }: {
+    a: number;
+    b: string;
+}) : void

--- a/test/fixtures/post/jsdoc-function.expected.d.ts
+++ b/test/fixtures/post/jsdoc-function.expected.d.ts
@@ -14,3 +14,11 @@ declare function woop(arg?: string): void
  * @param foo
  */
 export declare function exportedFn(foo): void
+
+/**
+ * @param options
+ */
+export function foo({ a, b }: {
+    a: number;
+    b: string;
+}) : void

--- a/test/fixtures/post/jsdoc.d.ts
+++ b/test/fixtures/post/jsdoc.d.ts
@@ -7,5 +7,5 @@
 export type EventListener = {
   callback: Function;
   next: EventListener|null;
-  number: priority;
+  priority: number;
 };

--- a/test/fixtures/post/jsdoc.expected.d.ts
+++ b/test/fixtures/post/jsdoc.expected.d.ts
@@ -1,5 +1,5 @@
 export type EventListener = {
   callback: Function;
   next: EventListener|null;
-  number: priority;
+  priority: number;
 };

--- a/test/fixtures/pre/jsdoc.expected.js
+++ b/test/fixtures/pre/jsdoc.expected.js
@@ -17,6 +17,13 @@ class Foo {
     this.wooop = function(yea) {
 
     };
+
+    /**
+     * @param { { foo: number, bar: string } } options
+     */
+    this.waap = function({ foo, bar }) {
+
+    };
   }
 
   /**

--- a/test/fixtures/pre/jsdoc.js
+++ b/test/fixtures/pre/jsdoc.js
@@ -14,6 +14,13 @@ function Foo(a, b) {
   this.wooop = function(yea) {
 
   };
+
+  /**
+   * @param { { foo: number, bar: string } } options
+   */
+  this.waap = function({ foo, bar }) {
+
+  };
 }
 
 /**

--- a/test/fixtures/snapshots/jsdoc.d.ts
+++ b/test/fixtures/snapshots/jsdoc.d.ts
@@ -21,6 +21,13 @@ declare class Foo {
      */
     wooop: (yea: string) => void;
     /**
+     * @param options
+     */
+    waap: ({ foo, bar }: {
+        foo: number;
+        bar: string;
+    }) => void;
+    /**
      * Not sour
      *
      * @param n

--- a/test/fixtures/snapshots/jsdoc.expected.d.ts
+++ b/test/fixtures/snapshots/jsdoc.expected.d.ts
@@ -21,6 +21,13 @@ declare class Foo {
      */
     wooop: (yea: string) => void;
     /**
+     * @param options
+     */
+    waap: ({ foo, bar }: {
+        foo: number;
+        bar: string;
+    }) => void;
+    /**
      * Not sour
      *
      * @param n


### PR DESCRIPTION
### Which issue does this PR address?

Allows us to properly generate types for the following construct:

```javascript
/**
 * @param { { foo: number, bar: string } } options
 */
function waap({ foo, bar }) {
  ...
}
```