### PR TITLE
Correct tests to generate + verify inheritance (E2E)

### DIFF
--- a/test/fixtures/pre/Bar.js
+++ b/test/fixtures/pre/Bar.js
@@ -1,0 +1,1 @@
+export default class Bar { }

--- a/test/fixtures/snapshots/declaration-map/Bar.d.ts
+++ b/test/fixtures/snapshots/declaration-map/Bar.d.ts
@@ -1,0 +1,3 @@
+export default class Bar {
+}
+//# sourceMappingURL=Bar.d.ts.map

--- a/test/fixtures/snapshots/declaration-map/Bar.d.ts.map
+++ b/test/fixtures/snapshots/declaration-map/Bar.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Bar.d.ts","sourceRoot":"","sources":["../../pre/Bar.js"],"names":[],"mappings":"AAAA;CAA4B"}

--- a/test/fixtures/snapshots/declaration-map/inheritance.d.ts
+++ b/test/fixtures/snapshots/declaration-map/inheritance.d.ts
@@ -1,7 +1,8 @@
-export class Woop {
+export class Woop extends Bar {
     constructor(a: any);
 }
-export default class Default {
+export default class Default extends Bar {
     constructor(a: any);
 }
+import Bar from './Bar';
 //# sourceMappingURL=inheritance.d.ts.map

--- a/test/fixtures/snapshots/declaration-map/inheritance.d.ts.map
+++ b/test/fixtures/snapshots/declaration-map/inheritance.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"inheritance.d.ts","sourceRoot":"","sources":["../../pre/inheritance.js"],"names":[],"mappings":"AAQA;IACE,oBAEC;CACF;AAED;IACE,oBAEC;CACF"}
+{"version":3,"file":"inheritance.d.ts","sourceRoot":"","sources":["../../pre/inheritance.js"],"names":[],"mappings":"AAQA;IACE,oBAEC;CACF;AAED;IACE,oBAEC;CACF;gBAlBe,OAAO"}

--- a/test/fixtures/snapshots/declaration-map/inheritance.expected.d.ts
+++ b/test/fixtures/snapshots/declaration-map/inheritance.expected.d.ts
@@ -1,7 +1,8 @@
-export class Woop {
+export class Woop extends Bar {
     constructor(a: any);
 }
-export default class Default {
+export default class Default extends Bar {
     constructor(a: any);
 }
+import Bar from './Bar';
 //# sourceMappingURL=inheritance.expected.d.ts.map

--- a/test/fixtures/snapshots/declaration-map/inheritance.expected.d.ts.map
+++ b/test/fixtures/snapshots/declaration-map/inheritance.expected.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"inheritance.expected.d.ts","sourceRoot":"","sources":["../../pre/inheritance.expected.js"],"names":[],"mappings":"AAQA;IACE,oBAEC;CACF;AAED;IACE,oBAEC;CACF"}
+{"version":3,"file":"inheritance.expected.d.ts","sourceRoot":"","sources":["../../pre/inheritance.expected.js"],"names":[],"mappings":"AAQA;IACE,oBAEC;CACF;AAED;IACE,oBAEC;CACF;gBAlBe,OAAO"}

--- a/test/fixtures/snapshots/default/Bar.d.ts
+++ b/test/fixtures/snapshots/default/Bar.d.ts
@@ -1,0 +1,2 @@
+export default class Bar {
+}

--- a/test/fixtures/snapshots/default/inheritance.d.ts
+++ b/test/fixtures/snapshots/default/inheritance.d.ts
@@ -1,6 +1,7 @@
-export class Woop {
+export class Woop extends Bar {
     constructor(a: any);
 }
-export default class Default {
+export default class Default extends Bar {
     constructor(a: any);
 }
+import Bar from './Bar';

--- a/test/fixtures/snapshots/default/inheritance.expected.d.ts
+++ b/test/fixtures/snapshots/default/inheritance.expected.d.ts
@@ -1,6 +1,7 @@
-export class Woop {
+export class Woop extends Bar {
     constructor(a: any);
 }
-export default class Default {
+export default class Default extends Bar {
     constructor(a: any);
 }
+import Bar from './Bar';


### PR DESCRIPTION
If a referenced file does not exist then inheritance related type definitions will silently be skipped by `tsc`. This fixes the setup so we generate correct output in our E2E tests.