### PR TITLE
feat: clean `extends` and `type` parameters

### DIFF
--- a/lib/post-transform.js
+++ b/lib/post-transform.js
@@ -509,10 +509,10 @@ declare function p${
 
       // remove full line including the non-TS tag
       if (
-        /class|constructor|template|method|typedef|property|this|overlord|overload/.test(tag.name) ||
+        /class|extends|type|constructor|template|method|typedef|property|this|overlord|overload/.test(tag.name) ||
         tag.param?.name?.includes('.')
       ) {
-        replacements.push([ { start: tag.start - 4, end: tag.end } ]);
+        replacements.push([ { start: Math.max(0, tag.start - 4), end: tag.end } ]);
 
         continue;
       }

--- a/test/fixtures/post/comments.d.ts
+++ b/test/fixtures/post/comments.d.ts
@@ -5,6 +5,16 @@
 /* */
 //
 
+/**
+ * @template { string } T
+ */
+declare class Bar<T> {}
+
+/**
+ * @class Foo
+ * @extends { Bar<'foo'> }
+ */
+declare class Foo extends Bar<'foo'> {}
 
 /** @type { number } */
 declare const foo = 1;

--- a/test/fixtures/post/comments.expected.d.ts
+++ b/test/fixtures/post/comments.expected.d.ts
@@ -2,7 +2,10 @@
 
 /** some comment */
 
-/** @type { number } */
+declare class Bar<T> {}
+
+declare class Foo extends Bar<'foo'> {}
+
 declare const foo = 1;
 
 /** some other comment */

--- a/test/fixtures/snapshots/default/jsdoc.d.ts
+++ b/test/fixtures/snapshots/default/jsdoc.d.ts
@@ -6,7 +6,6 @@ declare class Foo {
     /**
      * Static variable!
      *
-     * @type {boolean}
      */
     static bar: boolean;
     /**

--- a/test/fixtures/snapshots/default/jsdoc.expected.d.ts
+++ b/test/fixtures/snapshots/default/jsdoc.expected.d.ts
@@ -6,7 +6,6 @@ declare class Foo {
     /**
      * Static variable!
      *
-     * @type {boolean}
      */
     static bar: boolean;
     /**


### PR DESCRIPTION
Ensure that `@extends` and `@type` JSDoc annotations (properly represented as types in a `d.ts` file are cleaned from the JSDoc.