### PR TITLE
Improve class component tests

### DIFF
--- a/lib/post-transform.js
+++ b/lib/post-transform.js
@@ -509,7 +509,7 @@ declare function p${
 
       // remove full line including the non-TS tag
       if (
-        /class|extends|type|constructor|template|method|typedef|property|this|overlord|overload/.test(tag.name) ||
+        /class|function|extends|type|constructor|template|method|typedef|property|this|overlord|overload/.test(tag.name) ||
         tag.param?.name?.includes('.')
       ) {
         replacements.push([ { start: Math.max(0, tag.start - 4), end: tag.end } ]);

--- a/lib/pre-transform.js
+++ b/lib/pre-transform.js
@@ -1,5 +1,14 @@
 import { matcher, parse, path, print } from './util.js';
 
+/**
+ * @template T
+ * @typedef { import('./util.js').Path<T> } Path
+ */
+
+import {
+  parse as parseJSDoc
+} from './parsers/jsdoc.js';
+
 import {
   builders as b
 } from 'ast-types';
@@ -316,7 +325,14 @@ function findConstructors(nodes) {
 
     const name = identifier.value.name;
 
-    if (/^[A-Z]/.test(name)) {
+    // a class component
+    //
+    // * must start with upper letter
+    // * must not be tagged as @function
+    // * must not return something
+    //
+    if (isClassName(name) && !isFunctionTagged(node) && !isReturning(ctor)) {
+
       return {
         name,
         ctor,
@@ -324,6 +340,52 @@ function findConstructors(nodes) {
       };
     }
   }).filter(n => n);
+}
+
+/**
+ * @param { string } name
+ *
+ * @return {boolean}
+ */
+function isClassName(name) {
+
+  return /^[A-Z]/.test(name);
+}
+
+/**
+ * @param { Path<any> } nodePath
+ *
+ * @return { boolean }
+ */
+function isFunctionTagged(nodePath) {
+  const commentPaths = nodePath.get('comments');
+
+  // last comment is significant
+  const commentPath = commentPaths?.value && commentPaths.get(commentPaths.value.length - 1) || { value: null };
+
+  const doc = commentPath?.value?.value?.replace(/\n\s+/g, '\n ') || '';
+
+  if (!doc) {
+    return false;
+  }
+
+  const functionTagged = parseJSDoc(doc).some(tag => tag.name === 'function');
+
+  return functionTagged;
+}
+
+/**
+ * @param { Path<any> } ctorPath
+ *
+ * @return { boolean }
+ */
+function isReturning(ctorPath) {
+
+  const returnStatements = matcher`
+    return $1;
+  `;
+
+  return returnStatements(ctorPath.get('body', 'body')).length > 0;
 }
 
 function findStaticMembers(cls, nodes) {

--- a/test/fixtures/post/comments.d.ts
+++ b/test/fixtures/post/comments.d.ts
@@ -6,6 +6,11 @@
 //
 
 /**
+ * @function
+ */
+declare function blub(): boolean
+
+/**
  * @template { string } T
  */
 declare class Bar<T> {}

--- a/test/fixtures/post/comments.expected.d.ts
+++ b/test/fixtures/post/comments.expected.d.ts
@@ -2,6 +2,8 @@
 
 /** some comment */
 
+declare function blub(): boolean
+
 declare class Bar<T> {}
 
 declare class Foo extends Bar<'foo'> {}

--- a/test/fixtures/pre/class-detection.expected.js
+++ b/test/fixtures/pre/class-detection.expected.js
@@ -1,0 +1,24 @@
+export class AClass {
+  constructor() {
+
+    if (1 != 2) {
+      return;
+    }
+  }
+}
+
+export function NotAClass() {
+  return 15;
+}
+
+/**
+ * @function
+ */
+export function AlsoNotAClass() {
+
+  if (1 != 2) {
+    return 15;
+  } else {
+    return 20;
+  }
+}

--- a/test/fixtures/pre/class-detection.js
+++ b/test/fixtures/pre/class-detection.js
@@ -1,0 +1,22 @@
+export function AClass() {
+
+  if (1 != 2) {
+    return;
+  }
+}
+
+export function NotAClass() {
+  return 15;
+}
+
+/**
+ * @function
+ */
+export function AlsoNotAClass() {
+
+  if (1 != 2) {
+    return 15;
+  } else {
+    return 20;
+  }
+}

--- a/test/fixtures/snapshots/declaration-map/class-detection.d.ts
+++ b/test/fixtures/snapshots/declaration-map/class-detection.d.ts
@@ -1,0 +1,5 @@
+export function NotAClass(): number;
+export function AlsoNotAClass(): 15 | 20;
+export class AClass {
+}
+//# sourceMappingURL=class-detection.d.ts.map

--- a/test/fixtures/snapshots/declaration-map/class-detection.d.ts.map
+++ b/test/fixtures/snapshots/declaration-map/class-detection.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"class-detection.d.ts","sourceRoot":"","sources":["../../pre/class-detection.js"],"names":[],"mappings":"AASA,oCAEC;AAED;;GAEG;AACH,yCAOC;AAvBD;CAOC"}

--- a/test/fixtures/snapshots/declaration-map/class-detection.expected.d.ts
+++ b/test/fixtures/snapshots/declaration-map/class-detection.expected.d.ts
@@ -1,0 +1,5 @@
+export function NotAClass(): number;
+export function AlsoNotAClass(): 15 | 20;
+export class AClass {
+}
+//# sourceMappingURL=class-detection.expected.d.ts.map

--- a/test/fixtures/snapshots/declaration-map/class-detection.expected.d.ts.map
+++ b/test/fixtures/snapshots/declaration-map/class-detection.expected.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"class-detection.expected.d.ts","sourceRoot":"","sources":["../../pre/class-detection.expected.js"],"names":[],"mappings":"AASA,oCAEC;AAED;;GAEG;AACH,yCAOC;AAvBD;CAOC"}

--- a/test/fixtures/snapshots/declaration-map/jsdoc.d.ts
+++ b/test/fixtures/snapshots/declaration-map/jsdoc.d.ts
@@ -6,7 +6,6 @@ declare class Foo {
     /**
      * Static variable!
      *
-     * @type {boolean}
      */
     static bar: boolean;
     /**

--- a/test/fixtures/snapshots/declaration-map/jsdoc.expected.d.ts
+++ b/test/fixtures/snapshots/declaration-map/jsdoc.expected.d.ts
@@ -6,7 +6,6 @@ declare class Foo {
     /**
      * Static variable!
      *
-     * @type {boolean}
      */
     static bar: boolean;
     /**

--- a/test/fixtures/snapshots/default/class-detection.d.ts
+++ b/test/fixtures/snapshots/default/class-detection.d.ts
@@ -1,0 +1,4 @@
+export function NotAClass(): number;
+export function AlsoNotAClass(): 15 | 20;
+export class AClass {
+}

--- a/test/fixtures/snapshots/default/class-detection.expected.d.ts
+++ b/test/fixtures/snapshots/default/class-detection.expected.d.ts
@@ -1,0 +1,4 @@
+export function NotAClass(): number;
+export function AlsoNotAClass(): 15 | 20;
+export class AClass {
+}

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -18,6 +18,8 @@ describe('transform', function() {
 
     testPreTransform('pre/const');
 
+    testPreTransform('pre/class-detection');
+
     testPreTransform('pre/exports');
 
     testPreTransform('pre/generated-fns');


### PR DESCRIPTION
[This](https://github.com/nikku/bio-dts/commit/0afe3d57f2b3131995b0ddf83877ac611b2f5835) ensures we only transform actual ES5 classes to ES6 classes, not functional components made popular by front-end libraries.

```javascript
export function AClass() {

  if (1 != 2) {
    return;
  }
}

export function NotAClassBecauseReturning() {
  return 15;
}

/**
 * @function
 */
export function NotAClassBecauseExplicitlyDeclaredAsFunction() {

  if (1 != 2) {
    return 15;
  } else {
    return 20;
  }
}
```

This basic detection should be enough to cover a majority of use-cases. It is very unlikely, an anti-pattern to do the following (which will not be detected at this stage without a `@function` tag): 

```javascript
export function NotAClassBecauseExplicitlyDeclaredAsFunction() {

  if (1 != 2) {
    return 15;
  } else {
    return 20;
  }
}
```