### PR TITLE
Generate types in accordance with local `tsconfig.json`

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -9,6 +9,7 @@ import os from 'node:os';
 import fs from 'node:fs';
 
 import generateTypes from '../lib/generate-types.js';
+import { readTsConfigOptions } from '../lib/tsconfig.js';
 
 async function run() {
 
@@ -63,14 +64,18 @@ async function run() {
 
   console.log(`Generating types for ${files.length} files...`);
 
+  const tsConfigOptions = readTsConfigOptions(ts);
+
   const generateOptions = {
     allowJs: true,
     declaration: true,
     emitDeclarationOnly: true,
+    ...tsConfigOptions,
     ...options,
     verbose
   };
 
+  verbose && Object.keys(tsConfigOptions).length && console.log('Using tsconfig options', tsConfigOptions);
   verbose && console.log('Using options ', generateOptions);
 
   const {

--- a/lib/tsconfig.js
+++ b/lib/tsconfig.js
@@ -1,0 +1,43 @@
+import path from 'node:path';
+
+/**
+ * Read ESM-relevant compiler options from the nearest tsconfig.json,
+ * starting from `cwd`.
+ *
+ * Options are sourced selectively: only `module`, `moduleResolution`, and
+ * `target` are returned because these affect how declarations are generated.
+ * Other options (strict, lib, paths, …) are not meaningful here.
+ *
+ * @param { import('typescript') } ts
+ * @param { string } [cwd]
+ *
+ * @return { Partial<import('typescript').CompilerOptions> }
+ */
+export function readTsConfigOptions(ts, cwd = process.cwd()) {
+
+  const configPath = ts.findConfigFile(cwd, ts.sys.fileExists);
+
+  if (!configPath) {
+    return {};
+  }
+
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+
+  if (configFile.error) {
+    return {};
+  }
+
+  const { options } = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(configPath)
+  );
+
+  const result = /** @type { Partial<import('typescript').CompilerOptions> } */ ({});
+
+  if (options.module !== undefined) result.module = options.module;
+  if (options.moduleResolution !== undefined) result.moduleResolution = options.moduleResolution;
+  if (options.target !== undefined) result.target = options.target;
+
+  return result;
+}

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "check-types": "tsc --noEmit",
     "test": "mocha test",
     "test:dts": "run-s test:dts:*",
-    "test:dts:default": "node bin/cmd.js --outDir test/fixtures/snapshots/default -r test/fixtures/pre",
-    "test:dts:jsx": "node bin/cmd.js --jsx preserve --outDir test/fixtures/snapshots/jsx -r test/fixtures/jsx",
-    "test:dts:declaration-map": "node bin/cmd.js --declarationMap --outDir test/fixtures/snapshots/declaration-map -r test/fixtures/pre",
-    "test:dts:lax": "node bin/cmd.js --declarationMap --lax --outDir test/fixtures/snapshots/lax -r test/fixtures/lax"
+    "test:dts:default": "node bin/cmd.js --module CommonJS --outDir test/fixtures/snapshots/default -r test/fixtures/pre",
+    "test:dts:jsx": "node bin/cmd.js --module CommonJS --jsx preserve --outDir test/fixtures/snapshots/jsx -r test/fixtures/jsx",
+    "test:dts:declaration-map": "node bin/cmd.js --module CommonJS --declarationMap --outDir test/fixtures/snapshots/declaration-map -r test/fixtures/pre",
+    "test:dts:lax": "node bin/cmd.js --module CommonJS --declarationMap --lax --outDir test/fixtures/snapshots/lax -r test/fixtures/lax",
+    "test:dts:esm": "node bin/cmd.js --outDir test/fixtures/snapshots/esm -r test/fixtures/esm"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "all": "run-s lint check-types test test:dts:*",
+    "all": "run-s lint check-types test test:dts",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
     "test": "mocha test",
+    "test:dts": "run-s test:dts:*",
     "test:dts:default": "node bin/cmd.js --outDir test/fixtures/snapshots/default -r test/fixtures/pre",
     "test:dts:jsx": "node bin/cmd.js --jsx preserve --outDir test/fixtures/snapshots/jsx -r test/fixtures/jsx",
     "test:dts:declaration-map": "node bin/cmd.js --declarationMap --outDir test/fixtures/snapshots/declaration-map -r test/fixtures/pre",

--- a/test/fixtures/esm/Types.ts
+++ b/test/fixtures/esm/Types.ts
@@ -1,0 +1,4 @@
+export type Name = {
+  firstName: string;
+  lastName: string;
+}

--- a/test/fixtures/esm/base-greeter.js
+++ b/test/fixtures/esm/base-greeter.js
@@ -1,0 +1,1 @@
+export default function BaseGreeter() {}

--- a/test/fixtures/esm/basic.js
+++ b/test/fixtures/esm/basic.js
@@ -1,0 +1,26 @@
+import inherits from 'inherits-browser';
+
+import BaseGreeter from './base-greeter.js';
+
+/**
+ * @typedef { import('./Types.js').Name } Name
+ */
+
+/**
+ * @constructor
+ * @param {Name} name
+ */
+export function Greeter(name) {
+  /** @type {string} */
+  this.name = name;
+}
+
+inherits(Greeter, BaseGreeter);
+
+/**
+ * @param {Name} [greeting]
+ * @return {Name}
+ */
+Greeter.prototype.greet = function(greeting) {
+  return (greeting || 'Hello') + ', ' + this.name + '!';
+};

--- a/test/fixtures/pre/jsdoc-esm.expected.js
+++ b/test/fixtures/pre/jsdoc-esm.expected.js
@@ -1,0 +1,16 @@
+/**
+ * Great file!
+ */
+
+/**
+ * Foo
+ *
+ */
+export class Foo {
+  /**
+   * @param {import('./Bar.js').default} bar
+   */
+  constructor(bar) {
+
+  }
+}

--- a/test/fixtures/pre/jsdoc-esm.js
+++ b/test/fixtures/pre/jsdoc-esm.js
@@ -1,0 +1,12 @@
+/**
+ * Great file!
+ */
+
+/**
+ * Foo
+ *
+ * @param {import('./Bar.js').default} bar
+ */
+export function Foo(bar) {
+
+}

--- a/test/fixtures/snapshots/declaration-map/jsdoc-esm.d.ts
+++ b/test/fixtures/snapshots/declaration-map/jsdoc-esm.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Great file!
+ */
+/**
+ * Foo
+ *
+ */
+export class Foo {
+    /**
+     * @param bar
+     */
+    constructor(bar: import("./Bar.js").default);
+}
+//# sourceMappingURL=jsdoc-esm.d.ts.map

--- a/test/fixtures/snapshots/declaration-map/jsdoc-esm.d.ts.map
+++ b/test/fixtures/snapshots/declaration-map/jsdoc-esm.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"jsdoc-esm.d.ts","sourceRoot":"","sources":["../../pre/jsdoc-esm.js"],"names":[],"mappings":"AAAA;;GAEG;AAEH;;;GAGG;AACH;IACE;;OAEG;IACH,iBAFW,OAAO,UAAU,EAAE,OAAO,EAIpC;CACF"}

--- a/test/fixtures/snapshots/declaration-map/jsdoc-esm.expected.d.ts
+++ b/test/fixtures/snapshots/declaration-map/jsdoc-esm.expected.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Great file!
+ */
+/**
+ * Foo
+ *
+ */
+export class Foo {
+    /**
+     * @param bar
+     */
+    constructor(bar: import("./Bar.js").default);
+}
+//# sourceMappingURL=jsdoc-esm.expected.d.ts.map

--- a/test/fixtures/snapshots/declaration-map/jsdoc-esm.expected.d.ts.map
+++ b/test/fixtures/snapshots/declaration-map/jsdoc-esm.expected.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"jsdoc-esm.expected.d.ts","sourceRoot":"","sources":["../../pre/jsdoc-esm.expected.js"],"names":[],"mappings":"AAAA;;GAEG;AAEH;;;GAGG;AACH;IACE;;OAEG;IACH,iBAFW,OAAO,UAAU,EAAE,OAAO,EAIpC;CACF"}

--- a/test/fixtures/snapshots/default/jsdoc-esm.d.ts
+++ b/test/fixtures/snapshots/default/jsdoc-esm.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Great file!
+ */
+/**
+ * Foo
+ *
+ */
+export class Foo {
+    /**
+     * @param bar
+     */
+    constructor(bar: import("./Bar.js").default);
+}

--- a/test/fixtures/snapshots/default/jsdoc-esm.expected.d.ts
+++ b/test/fixtures/snapshots/default/jsdoc-esm.expected.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Great file!
+ */
+/**
+ * Foo
+ *
+ */
+export class Foo {
+    /**
+     * @param bar
+     */
+    constructor(bar: import("./Bar.js").default);
+}

--- a/test/fixtures/snapshots/esm/Types.d.ts
+++ b/test/fixtures/snapshots/esm/Types.d.ts
@@ -1,0 +1,4 @@
+export type Name = {
+    firstName: string;
+    lastName: string;
+};

--- a/test/fixtures/snapshots/esm/base-greeter.d.ts
+++ b/test/fixtures/snapshots/esm/base-greeter.d.ts
@@ -1,0 +1,2 @@
+export default class BaseGreeter {
+}

--- a/test/fixtures/snapshots/esm/basic.d.ts
+++ b/test/fixtures/snapshots/esm/basic.d.ts
@@ -1,0 +1,15 @@
+export class Greeter extends BaseGreeter {
+    /**
+     * @param name
+     */
+    constructor(name: Name);
+    name: string;
+    /**
+     * @param greeting
+     * @return
+     */
+    greet(greeting?: Name): Name;
+}
+
+type Name = import("./Types.js").Name;
+import BaseGreeter from './base-greeter.js';

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -30,6 +30,8 @@ describe('transform', function() {
 
     testPreTransform('pre/jsdoc');
 
+    testPreTransform('pre/jsdoc-esm');
+
     testPreTransform('pre/jsdoc-multi-comments');
 
     testPreTransform('pre/jsdoc-exports');

--- a/test/tsconfig.test.js
+++ b/test/tsconfig.test.js
@@ -1,0 +1,163 @@
+import Module from 'node:module';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { readTsConfigOptions } from 'bio-dts/lib/tsconfig.js';
+
+import { expect } from 'chai';
+
+
+/**
+ * @param { string } dir
+ * @param { object } config
+ */
+function writeTsConfig(dir, config) {
+  fs.writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify(config, null, 2));
+}
+
+
+describe('tsconfig', function() {
+
+  let tmpDir;
+
+  beforeEach(function() {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bio-dts-test-'));
+  });
+
+  afterEach(function() {
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+
+  describe('readTsConfigOptions', function() {
+
+    it('should read module from tsconfig', function() {
+
+      // given
+      const ts = getTypescript();
+
+      writeTsConfig(tmpDir, {
+        compilerOptions: {
+          module: 'NodeNext'
+        }
+      });
+
+      // when
+      const options = readTsConfigOptions(ts, tmpDir);
+
+      // then
+      expect(options.module).to.equal(ts.ModuleKind.NodeNext);
+    });
+
+
+    it('should read moduleResolution from tsconfig', function() {
+
+      // given
+      const ts = getTypescript();
+
+      writeTsConfig(tmpDir, {
+        compilerOptions: {
+          moduleResolution: 'NodeNext'
+        }
+      });
+
+      // when
+      const options = readTsConfigOptions(ts, tmpDir);
+
+      // then
+      expect(options.moduleResolution).to.equal(ts.ModuleResolutionKind.NodeNext);
+    });
+
+
+    it('should read target from tsconfig', function() {
+
+      // given
+      const ts = getTypescript();
+
+      writeTsConfig(tmpDir, {
+        compilerOptions: {
+          target: 'ES2020'
+        }
+      });
+
+      // when
+      const options = readTsConfigOptions(ts, tmpDir);
+
+      // then
+      expect(options.target).to.equal(ts.ScriptTarget.ES2020);
+    });
+
+
+    it('should return empty object when no tsconfig exists', function() {
+
+      // given
+      const ts = getTypescript();
+
+      // when — use os.tmpdir() as a directory that has no tsconfig above it
+      const options = readTsConfigOptions(ts, os.tmpdir());
+
+      // then
+      expect(options).to.eql({});
+    });
+
+
+    it('should not expose unrelated options', function() {
+
+      // given
+      const ts = getTypescript();
+
+      writeTsConfig(tmpDir, {
+        compilerOptions: {
+          module: 'NodeNext',
+          strict: true,
+          noImplicitAny: true,
+          lib: [ 'es2020' ]
+        }
+      });
+
+      // when
+      const options = readTsConfigOptions(ts, tmpDir);
+
+      // then
+      expect(options).to.not.have.property('strict');
+      expect(options).to.not.have.property('noImplicitAny');
+      expect(options).to.not.have.property('lib');
+    });
+
+
+    it('should read all three options together', function() {
+
+      // given
+      const ts = getTypescript();
+
+      writeTsConfig(tmpDir, {
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          target: 'ES2020'
+        }
+      });
+
+      // when
+      const options = readTsConfigOptions(ts, tmpDir);
+
+      // then
+      expect(options).to.eql({
+        module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        target: ts.ScriptTarget.ES2020
+      });
+    });
+
+  });
+
+});
+
+
+// helpers //////////////////
+
+function getTypescript() {
+  const requireLocal = Module.createRequire(import.meta.url);
+  return requireLocal('typescript');
+}


### PR DESCRIPTION
### Which issue does this PR address?

Ensures that `tsconfig.json` `module`, `moduleResolution` and `target` are taken into account during generation.